### PR TITLE
User-provided DEM and control flag for DEM used in EvhrToA process

### DIFF
--- a/model/AsterSrtmDem.py
+++ b/model/AsterSrtmDem.py
@@ -49,7 +49,7 @@ class AsterSrtmDem(InputDem):
                 self._logger.info(f'{envelope} is outside bounds or SRTM ' +
                                   'DEM, switching to ASTERGDEM')
 
-            self._demFootprintsPath = pathlib.Path(self.ASTER_FOOTPRINTS_PATH)
+            self._demFootprintsPath = self.ASTER_FOOTPRINTS_PATH
 
         self._mosaicAndClipDemTiles(self._demFootprintsPath,
                                     outDemName,

--- a/model/AsterSrtmDem.py
+++ b/model/AsterSrtmDem.py
@@ -49,8 +49,6 @@ class AsterSrtmDem(InputDem):
                 self._logger.info(f'{envelope} is outside bounds or SRTM ' +
                                   'DEM, switching to ASTERGDEM')
 
-            self._demFootprintsPath = self.ASTER_FOOTPRINTS_PATH
+            self._demFootprintsPath = pathlib.Path(self.ASTER_FOOTPRINTS_PATH)
 
-        self._mosaicAndClipDemTiles(self._demFootprintsPath,
-                                    outDemName,
-                                    envelope)
+        super().mosaicAndClipDemTiles(outDemName, envelope)

--- a/model/AsterSrtmDem.py
+++ b/model/AsterSrtmDem.py
@@ -3,7 +3,6 @@ import os
 import pathlib
 
 from core.model.Envelope import Envelope
-from core.model.SystemCommand import SystemCommand
 
 from evhr.model.InputDem import InputDem
 
@@ -31,43 +30,14 @@ class AsterSrtmDem(InputDem):
     # ------------------------------------------------------------------------
     def __init__(self, demDir: pathlib.Path,
                  logger: logging.Logger = None) -> None:
-
-        self._logger = logger
-
-        # Default to SRTM DEM.
-        self._demFootprintsPath = pathlib.Path(self.SRTM_FOOTPRINTS_PATH)
-
-        self._demDir = pathlib.Path(demDir)
-
-        if not self._demFootprintsPath.exists():
-
-            raise FileNotFoundError(self._demFootprintsPath)
-
-        if self._logger:
-
-            self._logger.info('DEM footprints shapefile: ' +
-                              str(self._demFootprintsPath))
-
-        if not self._demDir.exists():
-
-            errorMessage = f'{self._demDir} is expected to be created as'
-            ' part of the EvhrToA process but does not exist.'
-
-            raise FileNotFoundError(errorMessage)
-
-        self._validateDem()
+        super().__init__(self.SRTM_FOOTPRINTS_PATH, demDir, logger)
 
     # ------------------------------------------------------------------------
     # mosaicAndClipDemTiles
     # ------------------------------------------------------------------------
-    def mosaicAndClipDemTiles(self, outDemName: pathlib.Path,
+    def mosaicAndClipDemTiles(self,
+                              outDemName: pathlib.Path,
                               envelope: Envelope) -> None:
-
-        if self._logger:
-            self._logger.info(f'Creating DEM {str(outDemName)}')
-
-        outDemNameTemp = outDemName.replace('.tif', '-temp.tif')
-
         # ---
         # SRTM was collected between -54 and 60 degrees of latitude. Use
         # ASTERGDEM where SRTM is unavailable
@@ -81,50 +51,6 @@ class AsterSrtmDem(InputDem):
 
             self._demFootprintsPath = pathlib.Path(self.ASTER_FOOTPRINTS_PATH)
 
-            self._validateDem()
-
-        features = self._clipShp(envelope)
-
-        if not features or len(features) == 0:
-
-            msg = 'Clipping rectangles to supplied DEM footprints did not' + \
-                f' return any features. Corners: ({str(envelope.ulx())},' + \
-                f' {str(envelope.uly())}), ({str(envelope.lrx())},' + \
-                f' {str(envelope.lry())})'
-
-            return RuntimeError(msg)
-
-        tiles = []
-
-        for feature in features:
-
-            tileFile = str(feature.
-                           getElementsByTagName('ogr:location')[0].
-                           firstChild.
-                           data)
-
-            tiles.append(tileFile)
-
-        # Mosaic the tiles.
-        cmd = 'gdal_merge.py' + \
-              ' -o ' + outDemNameTemp + \
-              ' -ul_lr' + \
-              ' ' + str(envelope.ulx()) + \
-              ' ' + str(envelope.uly()) + \
-              ' ' + str(envelope.lrx()) + \
-              ' ' + str(envelope.lry()) + \
-              ' ' + ' '.join(tiles)
-
-        SystemCommand(cmd, self._logger, True)
-
-        # Run mosaicked DEM through geoid correction
-        cmd = self.BASE_SP_CMD + \
-            'dem_geoid ' + \
-            outDemNameTemp + ' --geoid EGM96 -o ' + \
-            outDemName.strip('-adj.tif') + \
-            ' --reverse-adjustment'
-
-        SystemCommand(cmd, self._logger, True)
-
-        for log in self._demDir.glob('*log*.txt'):
-            log.unlink()  # remove dem_geoid log file(s)
+        self._mosaicAndClipDemTiles(self._demFootprintsPath,
+                                    outDemName,
+                                    envelope)

--- a/model/AsterSrtmDem.py
+++ b/model/AsterSrtmDem.py
@@ -1,0 +1,130 @@
+import logging
+import os
+import pathlib
+
+from core.model.Envelope import Envelope
+from core.model.SystemCommand import SystemCommand
+
+from evhr.model.InputDem import InputDem
+
+
+# ----------------------------------------------------------------------------
+# class AsterSrtmDem
+#
+# EvhrToa -> AsterSrtmDem
+# ----------------------------------------------------------------------------
+class AsterSrtmDem(InputDem):
+    """
+    Class which handles verification and mosaicking of adapt-only DEM given
+    a footprints shapefile of the DEM.
+    """
+
+    SRTM_FOOTPRINTS_PATH: str = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), 'SRTM/srtm.shp'
+    )
+    ASTER_FOOTPRINTS_PATH: str = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), 'ASTERGDEM/astergdem.shp'
+    )
+
+    # ------------------------------------------------------------------------
+    # __init__
+    # ------------------------------------------------------------------------
+    def __init__(self, demDir: pathlib.Path,
+                 logger: logging.Logger = None) -> None:
+
+        self._logger = logger
+
+        # Default to SRTM DEM.
+        self._demFootprintsPath = pathlib.Path(self.SRTM_FOOTPRINTS_PATH)
+
+        self._demDir = pathlib.Path(demDir)
+
+        if not self._demFootprintsPath.exists():
+
+            raise FileNotFoundError(self._demFootprintsPath)
+
+        if self._logger:
+
+            self._logger.info('DEM footprints shapefile: ' +
+                              str(self._demFootprintsPath))
+
+        if not self._demDir.exists():
+
+            errorMessage = f'{self._demDir} is expected to be created as'
+            ' part of the EvhrToA process but does not exist.'
+
+            raise FileNotFoundError(errorMessage)
+
+        self._validateDem()
+
+    # ------------------------------------------------------------------------
+    # mosaicAndClipDemTiles
+    # ------------------------------------------------------------------------
+    def mosaicAndClipDemTiles(self, outDemName: pathlib.Path,
+                              envelope: Envelope) -> None:
+
+        if self._logger:
+            self._logger.info(f'Creating DEM {str(outDemName)}')
+
+        outDemNameTemp = outDemName.replace('.tif', '-temp.tif')
+
+        # ---
+        # SRTM was collected between -54 and 60 degrees of latitude. Use
+        # ASTERGDEM where SRTM is unavailable
+        # ---
+        if envelope.uly() < -54.0 or envelope.uly() > 60.0 or \
+                envelope.lry() < -54.0 or envelope.lry() > 60.0:
+
+            if self._logger:
+                self._logger.info(f'{envelope} is outside bounds or SRTM ' +
+                                  'DEM, switching to ASTERGDEM')
+
+            self._demFootprintsPath = pathlib.Path(self.ASTER_FOOTPRINTS_PATH)
+
+            self._validateDem()
+
+        features = self._clipShp(envelope)
+
+        if not features or len(features) == 0:
+
+            msg = 'Clipping rectangles to supplied DEM footprints did not' + \
+                f' return any features. Corners: ({str(envelope.ulx())},' + \
+                f' {str(envelope.uly())}), ({str(envelope.lrx())},' + \
+                f' {str(envelope.lry())})'
+
+            return RuntimeError(msg)
+
+        tiles = []
+
+        for feature in features:
+
+            tileFile = str(feature.
+                           getElementsByTagName('ogr:location')[0].
+                           firstChild.
+                           data)
+
+            tiles.append(tileFile)
+
+        # Mosaic the tiles.
+        cmd = 'gdal_merge.py' + \
+              ' -o ' + outDemNameTemp + \
+              ' -ul_lr' + \
+              ' ' + str(envelope.ulx()) + \
+              ' ' + str(envelope.uly()) + \
+              ' ' + str(envelope.lrx()) + \
+              ' ' + str(envelope.lry()) + \
+              ' ' + ' '.join(tiles)
+
+        SystemCommand(cmd, self._logger, True)
+
+        # Run mosaicked DEM through geoid correction
+        cmd = self.BASE_SP_CMD + \
+            'dem_geoid ' + \
+            outDemNameTemp + ' --geoid EGM96 -o ' + \
+            outDemName.strip('-adj.tif') + \
+            ' --reverse-adjustment'
+
+        SystemCommand(cmd, self._logger, True)
+
+        for log in self._demDir.glob('*log*.txt'):
+            log.unlink()  # remove dem_geoid log file(s)

--- a/model/AsterSrtmDem.py
+++ b/model/AsterSrtmDem.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import pathlib
 
 from core.model.Envelope import Envelope
@@ -18,12 +17,13 @@ class AsterSrtmDem(InputDem):
     a footprints shapefile of the DEM.
     """
 
-    SRTM_FOOTPRINTS_PATH: str = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), 'SRTM/srtm.shp'
-    )
-    ASTER_FOOTPRINTS_PATH: str = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), 'ASTERGDEM/astergdem.shp'
-    )
+    CUR_FILE_PARENT: pathlib.Path = pathlib.Path(__file__).resolve().parent
+
+    SRTM_FOOTPRINTS_PATH: pathlib.Path = CUR_FILE_PARENT / \
+        'SRTM/srtm.shp'
+
+    ASTER_FOOTPRINTS_PATH: pathlib.Path = CUR_FILE_PARENT / \
+        'ASTERGDEM/astergdem.shp'
 
     # ------------------------------------------------------------------------
     # __init__
@@ -49,6 +49,6 @@ class AsterSrtmDem(InputDem):
                 self._logger.info(f'{envelope} is outside bounds or SRTM ' +
                                   'DEM, switching to ASTERGDEM')
 
-            self._demFootprintsPath = pathlib.Path(self.ASTER_FOOTPRINTS_PATH)
+            self._demFootprintsPath = self.ASTER_FOOTPRINTS_PATH
 
         super().mosaicAndClipDemTiles(outDemName, envelope)

--- a/model/EvhrToA.py
+++ b/model/EvhrToA.py
@@ -95,7 +95,7 @@ class EvhrToA(object):
                                       self._demDir,
                                       self._logger)
         else:
-            self._logger.info('Got no user-supplied DEM, defaulting to' + \
+            self._logger.info('No user-supplied DEM, defaulting to' + \
                               ' ADAPT SRTM/ASTERGDEM')
             self._inputDem = AsterSrtmDem(self._demDir, self._logger)
 

--- a/model/EvhrToA.py
+++ b/model/EvhrToA.py
@@ -91,7 +91,9 @@ class EvhrToA(object):
             self._logger.info('ToA directory: ' + self._toaDir)
 
         if inputDemPath:
-            self._inputDem = InputDem(inputDemPath, self._demDir, self._logger)
+            self._inputDem = InputDem(inputDemPath,
+                                      self._demDir,
+                                      self._logger)
         else:
             self._logger.info('Got no user-supplied DEM, defaulting to' + \
                               ' ADAPT SRTM/ASTERGDEM')

--- a/model/EvhrToaCelery.py
+++ b/model/EvhrToaCelery.py
@@ -18,13 +18,14 @@ class EvhrToaCelery(EvhrToA):
     # -------------------------------------------------------------------------
     # __init__
     # -------------------------------------------------------------------------
-    def __init__(self, outDir, panResolution=1, panSharpen=False,
-                 unusedLogger=None):
+    def __init__(self, outDir, inputDemPath=None, panResolution=1,
+                 panSharpen=False, unusedLogger=None):
 
         logger.info('In EvhrToaCelery.__init__')
 
         # Initialize the base class.
         super(EvhrToaCelery, self).__init__(outDir,
+                                            inputDemPath,
                                             panResolution,
                                             panSharpen,
                                             unusedLogger)
@@ -36,7 +37,7 @@ class EvhrToaCelery(EvhrToA):
     # -------------------------------------------------------------------------
     def processStrips(self, stripsWithScenes, bandDir, stripDir, orthoDir,
                       demDir, toaDir, outSrsProj4, panResolution, panSharpen,
-                      unusedLogger):
+                      inputDem, unusedLogger):
 
         logger.info('In EvhrToaCelery.processStrips')
 
@@ -51,6 +52,7 @@ class EvhrToaCelery(EvhrToA):
             outSrsProj4,
             panResolution,
             panSharpen,
+            inputDem,
             logger) for key in iter(stripsWithScenes))
 
         result = wpi.apply_async()
@@ -67,7 +69,7 @@ class EvhrToaCelery(EvhrToA):
     @app.task(serializer='pickle')
     def _runOneStrip(stripID, scenes, bandDir, stripDir, orthoDir, demDir,
                      toaDir, outSrsProj4, panResolution, panSharpen,
-                     unusedLogger, thisToaIsForPanSharpening=False):
+                     inputDem, unusedLogger, thisToaIsForPanSharpening=False):
 
         logger.info('In EvhrToaCelery._runOneStrip')
 
@@ -82,6 +84,7 @@ class EvhrToaCelery(EvhrToA):
 
         EvhrToA._stripToToa(imageForEachBandInStrip,
                             toaName,
+                            inputDem,
                             orthoDir,
                             demDir,
                             toaDir,

--- a/model/InputDem.py
+++ b/model/InputDem.py
@@ -46,28 +46,17 @@ class InputDem(object):
     # mosaicAndClipDemTiles
     # ------------------------------------------------------------------------
     def mosaicAndClipDemTiles(self,
-                                 outDemName: pathlib.Path,
-                                 envelope: Envelope) -> None:
-
-        self._mosaicAndClipDemTiles(
-            self._demFootprintsPath, outDemName, envelope)
-
-    # ------------------------------------------------------------------------
-    # _mosaicAndClipDemTiles
-    # ------------------------------------------------------------------------
-    def _mosaicAndClipDemTiles(self,
-                               demFootprintsPath: pathlib.Path,
-                               outDemName: pathlib.Path,
-                               envelope: Envelope) -> None:
+                              outDemName: pathlib.Path,
+                              envelope: Envelope) -> None:
 
         # Validate both footprints and DEM exist and are readable.
-        self._validateDem(demFootprintsPath)
+        self._validateDem(self._demFootprintsPath)
 
         if self._logger:
             self._logger.info(f'Creating DEM {str(outDemName)}')
 
         # Clip the footprints to the envelope extent.
-        features = self._clipShp(demFootprintsPath, envelope)
+        features = self._clipShp(self._demFootprintsPath, envelope)
 
         # Mosaic the DEM rasters (features) that overlap the envelope extent.
         self._mosaicDem(features, outDemName, envelope)
@@ -173,7 +162,8 @@ class InputDem(object):
         SystemCommand(cmd, self._logger, True)
 
         for log in self._demDir.glob('*log*.txt'):
-            log.unlink()  # remove dem_geoid log file(s)
+            # remove geoid process logs
+            log.unlink()
 
     # -------------------------------------------------------------------------
     # _validateDem

--- a/model/InputDem.py
+++ b/model/InputDem.py
@@ -26,12 +26,12 @@ class InputDem(object):
     # ------------------------------------------------------------------------
     # __init__
     # ------------------------------------------------------------------------
-    def __init__(self, demFootprintsPath: str, demDir: str,
+    def __init__(self, demFootprintsPath: pathlib.Path, demDir: str,
                  logger: logging.Logger = None) -> None:
 
         self._logger = logger
 
-        self._demFootprintsPath = pathlib.Path(demFootprintsPath)
+        self._demFootprintsPath = demFootprintsPath
 
         self._demDir = pathlib.Path(demDir)
 

--- a/model/InputDem.py
+++ b/model/InputDem.py
@@ -1,0 +1,219 @@
+import logging
+import pathlib
+import tempfile
+from xml.dom import minidom
+
+from osgeo import ogr
+from osgeo import gdal
+
+from core.model.Envelope import Envelope
+from core.model.SystemCommand import SystemCommand
+
+
+# ----------------------------------------------------------------------------
+# class InputDem
+#
+# EvhrToa -> InputDem
+# ----------------------------------------------------------------------------
+class InputDem(object):
+    """
+    Class which handles verification and mosaicking of user-supplied DEM given
+    a footprints shapefile of the DEM.
+    """
+
+    BASE_SP_CMD = '/opt/StereoPipeline/bin/'
+
+    # ------------------------------------------------------------------------
+    # __init__
+    # ------------------------------------------------------------------------
+    def __init__(self, demFootprintsPath: pathlib.Path, demDir: pathlib.Path,
+                 logger: logging.Logger = None) -> None:
+
+        self._logger = logger
+
+        self._demFootprintsPath = pathlib.Path(demFootprintsPath)
+
+        self._demDir = pathlib.Path(demDir)
+
+        if not self._demFootprintsPath.exists():
+
+            raise FileNotFoundError(self._demFootprintsPath)
+
+        if self._logger:
+
+            self._logger.info('DEM footprints shapefile: ' +
+                              str(self._demFootprintsPath))
+
+        if not self._demDir.exists():
+
+            errorMessage = f'{self._demDir} is expected to be created as'
+            ' part of the EvhrToA process but does not exist.'
+
+            raise FileNotFoundError(errorMessage)
+
+        self._validateDem()
+
+    # ------------------------------------------------------------------------
+    # mosaicAndClipDemTiles
+    # ------------------------------------------------------------------------
+    def mosaicAndClipDemTiles(self, outDemName: pathlib.Path,
+                              envelope: Envelope) -> None:
+
+        if self._logger:
+            self._logger.info(f'Creating DEM {str(outDemName)}')
+
+        outDemNameTemp = outDemName.replace('.tif', '-temp.tif')
+
+        features = self._clipShp(envelope)
+
+        if not features or len(features) == 0:
+
+            msg = 'Clipping rectangles to supplied DEM footprints did not'
+            f' return any features. Corners: ({str(envelope.ulx())},'
+            f' {str(envelope.uly())}), ({str(envelope.lrx())},'
+            f' {str(envelope.lry())})'
+
+            return RuntimeError(msg)
+
+        tiles = []
+
+        for feature in features:
+
+            tileFile = str(feature.
+                           getElementsByTagName('ogr:location')[0].
+                           firstChild.
+                           data)
+
+            tiles.append(tileFile)
+
+        # Mosaic the tiles.
+        cmd = 'gdal_merge.py' + \
+              ' -o ' + outDemNameTemp + \
+              ' -ul_lr' + \
+              ' ' + str(envelope.ulx()) + \
+              ' ' + str(envelope.uly()) + \
+              ' ' + str(envelope.lrx()) + \
+              ' ' + str(envelope.lry()) + \
+              ' ' + ' '.join(tiles)
+
+        SystemCommand(cmd, self._logger, True)
+
+        # Run mosaicked DEM through geoid correction
+        cmd = self.BASE_SP_CMD + \
+            'dem_geoid ' + \
+            outDemNameTemp + ' --geoid EGM96 -o ' + \
+            outDemName.strip('-adj.tif') + \
+            ' --reverse-adjustment'
+
+        SystemCommand(cmd, self._logger, True)
+
+        for log in self._demDir.glob('*log*.txt'):
+            log.unlink()  # remove dem_geoid log file(s)
+
+    # ------------------------------------------------------------------------
+    # _clipShp
+    # ------------------------------------------------------------------------
+    def _clipShp(self, envelope: Envelope):
+
+        if self._logger:
+            self._logger.info(f'Clipping shapefile {self._demFootprintsPath}')
+
+        # Create a temporary file for the clip output.
+        tempClipFile = tempfile.mkstemp()[1]
+
+        # ---
+        # To filter scenes that only overlap the AoI slightly, decrease both
+        # corners of the query AoI.
+        # ---
+        MIN_OVERLAP_IN_DEGREES = 0.02
+        ulx = float(envelope.ulx()) + MIN_OVERLAP_IN_DEGREES
+        uly = float(envelope.uly()) - MIN_OVERLAP_IN_DEGREES
+        lrx = float(envelope.lrx()) - MIN_OVERLAP_IN_DEGREES
+        lry = float(envelope.lry()) + MIN_OVERLAP_IN_DEGREES
+
+        # Clip.  The debug option somehow prevents an occasional seg. fault!
+        cmd = 'ogr2ogr' + \
+              ' -f "GML"' + \
+              ' -spat' + \
+              ' ' + str(ulx) + \
+              ' ' + str(lry) + \
+              ' ' + str(lrx) + \
+              ' ' + str(uly) + \
+              ' -spat_srs' + \
+              ' "' + envelope.GetSpatialReference().ExportToProj4() + '"' + \
+              ' --debug on'
+
+        # ---
+        # This was in the EVHR project, but I do not remember why it is
+        # important.
+        # ---
+        MAXIMUM_SCENES = 5
+        cmd += ' -limit ' + str(MAXIMUM_SCENES)
+
+        cmd += ' "' + tempClipFile + '"' + \
+               ' "' + str(self._demFootprintsPath) + '"'
+
+        SystemCommand(cmd, self._logger, True)
+
+        xml = minidom.parse(tempClipFile)
+        features = xml.getElementsByTagName('gml:featureMember')
+
+        return features
+
+    # -------------------------------------------------------------------------
+    # _validateDem
+    # -------------------------------------------------------------------------
+    def _validateDem(self) -> None:
+
+        demShapeFilePath = self._demFootprintsPath
+
+        # Test that ogr can open the footprints file and access features.
+        try:
+
+            demShapeSource = ogr.Open(str(demShapeFilePath))
+
+            demShapeLayer = demShapeSource.GetLayer()
+
+            demShapeSampleFeature = demShapeLayer.GetNextFeature()
+
+            demShapeSampleLocation = demShapeSampleFeature.GetField("location")
+
+        except Exception as e:
+
+            errorMessage = 'Error opening or accessing layers and' + \
+                f' fields of {str(demShapeFilePath)}, Error: {e}'
+
+            raise RuntimeError(errorMessage)
+
+        # Get a path to the DEM, check if it exists
+        demShapeSamplePath = pathlib.Path(demShapeSampleLocation)
+
+        if not demShapeSamplePath.exists():
+
+            errorMessage = 'DEM footprints shapefile must point to a file' + \
+                f' that exist. Cannot find: {demShapeSamplePath}'
+
+            raise FileNotFoundError(errorMessage)
+
+        # Attempt to open the sampled DEM with GDAL.
+        try:
+
+            dataset = gdal.Open(str(demShapeSamplePath), gdal.GA_ReadOnly)
+
+            if dataset is None:
+
+                errorMessage = 'Dataset is none. Unable to open' + \
+                    f' {str(demShapeSamplePath)}'
+
+                raise RuntimeError(errorMessage)
+
+            dataset = None
+
+        except Exception as e:
+
+            errorMessage = f'Error opening {str(demShapeSamplePath)}' + \
+                ' using GDAL. Please pass a valid footprints file which' + \
+                ' contains a field "location" that is a path to a valid' + \
+                f' DEM readable by GDAL. Error: {e}'
+
+            raise RuntimeError(errorMessage)

--- a/model/tests/test_InputDem.py
+++ b/model/tests/test_InputDem.py
@@ -35,7 +35,8 @@ class InputDemTestCase(unittest.TestCase):
 
         with self.assertRaises(FileNotFoundError):
 
-            InputDem(self.DEM_NOT_EXISTS, self.DEM_DIR_EXISTS, None)
+            testDem = InputDem(self.DEM_NOT_EXISTS, self.DEM_DIR_EXISTS, None)
+            testDem._validateDem(self.DEM_NOT_EXISTS)
 
         with self.assertRaisesRegex(FileNotFoundError, 'is expected to be'):
 
@@ -43,7 +44,8 @@ class InputDemTestCase(unittest.TestCase):
 
         try:
 
-            InputDem(self.DEM_EXISTS, self.DEM_DIR_EXISTS, None)
+            testDem = InputDem(self.DEM_EXISTS, self.DEM_DIR_EXISTS, None)
+            testDem._validateDem(self.DEM_EXISTS)
 
         except Exception as e:
 

--- a/model/tests/test_InputDem.py
+++ b/model/tests/test_InputDem.py
@@ -1,0 +1,51 @@
+import os
+import pathlib
+import sys
+
+import unittest
+from unittest.mock import MagicMock
+from unittest.mock import Mock
+
+sys.modules['core.model.Envelope'] = Mock()
+sys.modules['core.model.SystemCommand'] = Mock()
+
+from evhr.model.InputDem import InputDem
+
+# ----------------------------------------------------------------------------
+# InputDemTestCase
+# ----------------------------------------------------------------------------
+class InputDemTestCase(unittest.TestCase):
+
+    CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+    DEM_EXISTS = os.path.join(CURRENT_DIR,
+                              '../ASTERGDEM/astergdem.shp')
+    DEM_EXISTS = pathlib.Path(DEM_EXISTS)
+
+    DEM_NOT_EXISTS = pathlib.Path('DEM_NOT_EXIST.shp')
+
+    DEM_DIR_EXISTS = pathlib.Path('.')
+
+    DEM_DIR_NOT_EXISTS = pathlib.Path('.DEM_DIR_NOT_EXIST')
+
+    # ------------------------------------------------------------------------
+    # 
+    # ------------------------------------------------------------------------
+    def test_init(self):
+
+        with self.assertRaises(FileNotFoundError):
+
+            InputDem(self.DEM_NOT_EXISTS, self.DEM_DIR_EXISTS, None)
+
+        with self.assertRaisesRegex(FileNotFoundError, 'is expected to be'):
+
+            InputDem(self.DEM_EXISTS, self.DEM_DIR_NOT_EXISTS, None)
+
+        try:
+
+            InputDem(self.DEM_EXISTS, self.DEM_DIR_EXISTS, None)
+
+        except Exception as e:
+
+            print('Unittest not being run on ADAPT')
+            print(e)

--- a/view/evhrToaCLV.py
+++ b/view/evhrToaCLV.py
@@ -115,8 +115,6 @@ def main():
 
     else:
 
-        print(args.dem)
-        print(args.o)
         toa = EvhrToA(args.o, args.dem, args.pan_res, args.pan_sharpen, logger)
         toa.run(dgScenes)
 

--- a/view/evhrToaCLV.py
+++ b/view/evhrToaCLV.py
@@ -50,7 +50,7 @@ def main():
                              'ToA images.')
 
     parser.add_argument('--dem',
-                        type=str,
+                        type=pathlib.Path,
                         required=False,
                         help='Fully-qualified path to DEM footprints shape '
                              ' file.')

--- a/view/evhrToaCLV.py
+++ b/view/evhrToaCLV.py
@@ -48,6 +48,11 @@ def main():
                         action='store_true',
                         help='Apply panchromatic sharpening to the output '
                              'ToA images.')
+    
+    parser.add_argument('--dem',
+                        type=pathlib.Path,
+                        help='Fully-qualified path to DEM footprints shape '
+                             ' file.')
 
     group = parser.add_mutually_exclusive_group(required=True)
 
@@ -63,6 +68,8 @@ def main():
 
     args = parser.parse_args()
 
+    print(args.dem)
+
     print('GDAL version:', gdal.__version__)
 
     # ---
@@ -74,7 +81,7 @@ def main():
 
         with open(args.scenes_in_file, newline='') as csvFile:
             reader = csv.reader(csvFile)
-            scenes = [scene[0] for scene in reader]
+            scenes = [pathlib.Path(scene[0]) for scene in reader]
 
     # ---
     # Logging
@@ -108,7 +115,7 @@ def main():
 
     else:
 
-        toa = EvhrToA(args.o, args.pan_res, args.pan_sharpen, logger)
+        toa = EvhrToA(args.o, args.dem, args.pan_res, args.pan_sharpen, logger)
         toa.run(dgScenes)
 
 

--- a/view/evhrToaCLV.py
+++ b/view/evhrToaCLV.py
@@ -48,7 +48,7 @@ def main():
                         action='store_true',
                         help='Apply panchromatic sharpening to the output '
                              'ToA images.')
-    
+
     parser.add_argument('--dem',
                         type=str,
                         required=False,
@@ -115,6 +115,8 @@ def main():
 
     else:
 
+        print(args.dem)
+        print(args.o)
         toa = EvhrToA(args.o, args.dem, args.pan_res, args.pan_sharpen, logger)
         toa.run(dgScenes)
 

--- a/view/evhrToaCLV.py
+++ b/view/evhrToaCLV.py
@@ -50,7 +50,8 @@ def main():
                              'ToA images.')
     
     parser.add_argument('--dem',
-                        type=pathlib.Path,
+                        type=str,
+                        required=False,
                         help='Fully-qualified path to DEM footprints shape '
                              ' file.')
 
@@ -67,8 +68,6 @@ def main():
                             'list of scene files')
 
     args = parser.parse_args()
-
-    print(args.dem)
 
     print('GDAL version:', gdal.__version__)
 
@@ -110,7 +109,8 @@ def main():
 
         with ILProcessController('evhr.model.CeleryConfiguration'):
 
-            toa = EvhrToaCelery(args.o, args.pan_res, args.pan_sharpen, logger)
+            toa = EvhrToaCelery(args.o, args.dem, args.pan_res,
+                                args.pan_sharpen, logger)
             toa.run(dgScenes)
 
     else:

--- a/view/test.py
+++ b/view/test.py
@@ -1,4 +1,0 @@
-
-import os
-print(os.path.realpath(__file__))
-print(os.path.dirname(os.path.realpath(__file__)))

--- a/view/test.py
+++ b/view/test.py
@@ -1,0 +1,4 @@
+
+import os
+print(os.path.realpath(__file__))
+print(os.path.dirname(os.path.realpath(__file__)))


### PR DESCRIPTION
# Description
This diff moves the dem clipping and mosaicking functionality into its own class. This allows for users to give paths to their own DEM's (through a path to the footprints shapefile or geopackage).  See #13. 

## evhrToaCLV.py
- Added optional command-line argument `--dem`, user should supply a DEM footprints path

## EvhrToA.py
- Removed DEM-specific code from the class.
- On initialization, if a dem footprints path was provided, the input DEM class will be the InputDem object, if not AsterSrtmDem (adapt-specific case)

## InputDem.py
- Implements basic validation of the existence of the DEM the shapefile is pointing to through opening the shapefile using ogr and getting the first path to the DEM.
- Checks that that DEM path exists and gdal can open the DEM file.
- Implements the clipping and mosaicking functionality previously in EvhrToA (without SRTM/ASTERGDEM specific logic)

## AsterSrtmDem.py (adapt specific class)
- Uses the shapefiles provided with the evhr source code
- Performs latitude checking to determine which DEM source to use

## EvhrToaCelery.py
- Updated function and init args to match EvhrToA 

Additional edits:
- Outputs should not change if using SRTM/ASTER default method
- Outside testing done by @mfrost2NCCS 
- Passes unit tests
- Will need to communicate in documentation how users can create the needed footprints from a dem raster