### PR TITLE
added default cog support to DemCreator

### DIFF
--- a/model/DemCreatorCelery.py
+++ b/model/DemCreatorCelery.py
@@ -16,15 +16,13 @@ class DemCreatorCelery(DemCreator):
     # -------------------------------------------------------------------------
     # __init__
     # -------------------------------------------------------------------------
-    def __init__(self, outDir, unusedLogger=None, testMode=False,
-                 createCOG=False):
+    def __init__(self, outDir, unusedLogger=None, testMode=False):
 
         if logger:
             logger.info('In DemCreatorCelery.__init__')
 
         # Initialize the base class.
-        super(DemCreatorCelery, self).__init__(outDir, unusedLogger, testMode,
-                                               createCOG)
+        super(DemCreatorCelery, self).__init__(outDir, unusedLogger, testMode)
 
     # -------------------------------------------------------------------------
     # processPairs
@@ -41,12 +39,11 @@ class DemCreatorCelery(DemCreator):
                         pairs[key],
                         self._outDir,
                         self._testMode,
-                        self._createCOG,
                         logger) for key in pairs)
 
         result = wpi.apply_async()
         result.get()    # Waits for wpi to finish.
-            
+
         return result
 
     # -------------------------------------------------------------------------
@@ -54,11 +51,9 @@ class DemCreatorCelery(DemCreator):
     # -------------------------------------------------------------------------
     @staticmethod
     @app.task(serializer='pickle')
-    def _processPair(pairName, dgScenes, outDir, testMode, createCOG,
-                     unusedLogger):
+    def _processPair(pairName, dgScenes, outDir, testMode, unusedLogger):
 
         if logger:
             logger.info('In DemCreatorCelery._processPair')
 
-        DemCreator._processPair(pairName, dgScenes, outDir, testMode,
-                                createCOG, logger)
+        DemCreator._processPair(pairName, dgScenes, outDir, testMode, logger)

--- a/model/EvhrUtils.py
+++ b/model/EvhrUtils.py
@@ -1,0 +1,27 @@
+import logging
+import pathlib
+from typing import Union
+
+from osgeo import gdal
+
+
+class EvhrUtils(object):
+
+    @staticmethod
+    def createCloudOptimizedGeotiff(destPath: Union[str, pathlib.Path],
+                                    srcPath: Union[str, pathlib.Path],
+                                    logger: logging.Logger = None) -> None:
+        translate_options = {
+            'format': 'COG',
+            'creationOptions': ['BIGTIFF=YES',
+                                'COMPRESS=LZW'],
+        }
+
+        if logger:
+            logger.info(f'Translating {srcPath} to COG {destPath}')
+
+        options = gdal.TranslateOptions(**translate_options)
+
+        ds = gdal.Translate(str(destPath), str(srcPath), options=options)
+
+        ds = None

--- a/model/tests/test_InputDem.py
+++ b/model/tests/test_InputDem.py
@@ -3,13 +3,13 @@ import pathlib
 import sys
 
 import unittest
-from unittest.mock import MagicMock
 from unittest.mock import Mock
 
 sys.modules['core.model.Envelope'] = Mock()
 sys.modules['core.model.SystemCommand'] = Mock()
 
 from evhr.model.InputDem import InputDem
+
 
 # ----------------------------------------------------------------------------
 # InputDemTestCase
@@ -29,7 +29,7 @@ class InputDemTestCase(unittest.TestCase):
     DEM_DIR_NOT_EXISTS = pathlib.Path('.DEM_DIR_NOT_EXIST')
 
     # ------------------------------------------------------------------------
-    # 
+    # test_init
     # ------------------------------------------------------------------------
     def test_init(self):
 

--- a/view/demCreatorCLV.py
+++ b/view/demCreatorCLV.py
@@ -18,7 +18,6 @@ from evhr.model.DemCreatorCelery import DemCreatorCelery
 # evhr/view/demCreatorCLV.py -t \
 #    -o /explore/nobackup/projects/ilab/scratch/SystemTesting/evhr/testDEM \
 #    --pairs_in_file /explore/nobackup/projects/ilab/scratch/SystemTesting/evhr/testDEM/demcreator_test_1_pair.csv \
-#    --cog \
 #    --logToFile
 # -----------------------------------------------------------------------------
 def main():
@@ -35,10 +34,6 @@ def main():
     parser.add_argument('--celery',
                         action='store_true',
                         help='Use Celery for distributed processing.')
-
-    parser.add_argument('--cog',
-                        action='store_true',
-                        help='Create cloud-optimized GeoTiffs.')
 
     parser.add_argument('--logToFile',
                         action='store_true',
@@ -98,13 +93,13 @@ def main():
         with ILProcessController('evhr.model.CeleryConfiguration') as \
              processController:
 
-            dc = DemCreatorCelery(args.o, logger, args.t, args.cog)
+            dc = DemCreatorCelery(args.o, logger, args.t)
 
             dc.runPairs(pairs)
 
     else:
 
-        dc = DemCreator(args.o, logger, args.t, args.cog)
+        dc = DemCreator(args.o, logger, args.t)
 
         dc.runPairs(pairs)
 


### PR DESCRIPTION
# Description
This diff makes the generation of cloud optimized geotiff (CoGs) the default behavior when writing out data to GeoTiff. Adds this support for DemCreator and EvhrToA and their multi-processing enabled implementations. See #28.

## EvhrToA.py
- Added CoG writing support when merging band files into single TOA. Writes a temp non-cog file then uses gdal to generate the final GeoTiff w/ CoG format.

## DemCreator.py
- Removed option to create with CoG, made it default behavior.

## DemCreatorCelery.py
- Same as DemCreator, removed arguments that control CoG generation as it will be default behavior. 

## demCreatorCLV.py
- Removed command-line arg for cog generation.

## EvhrUtils.py
- Implemented a CoG generation function, this allows it to be called from both EvhrToA and DemCreator, as opposed to repeating code in each class.

Additional edits:
- 3rd party tested functionality by @ssfinch 
- Passes unit tests
- Will need to communicate in documentation this change